### PR TITLE
search for Panda3D directly if not found

### DIFF
--- a/meshtool/__main__.py
+++ b/meshtool/__main__.py
@@ -1,4 +1,15 @@
 import sys
+#
+# Unfortunate kluge to get to panda3d from old distribution
+# this allows meshtool to run on Ubuntu 12.04
+#
+try:
+    import panda3d
+except:
+    print "panda3d not found -- searching harder"
+    sys.path.append("/usr/share/panda3d")
+    sys.path.append("/usr/lib64/panda3d")
+    import panda3d    
 import argparse
 from collections import defaultdict
 import meshtool.filters as filters

--- a/meshtool/__main__.py
+++ b/meshtool/__main__.py
@@ -6,7 +6,7 @@ import sys
 try:
     import panda3d
 except:
-    print "panda3d not found -- searching harder"
+    print >> sys.stderr, 'panda3d not found -- adding to sys.path and trying again'
     sys.path.append("/usr/share/panda3d")
     sys.path.append("/usr/lib64/panda3d")
     import panda3d    


### PR DESCRIPTION
This allows meshtool to run in Ubuntu 12.04 (and presumably other distros) in spite of the fact that the panda3d python bindings are installed in python2.6.

It accomplishes this by explicitly adding the panda search path (as seen in panda3d.pth) to sys.path.
